### PR TITLE
Increase request timeout from 10 s to 30 s

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>scala-group-emailer_2.11</artifactId>
     <packaging>jar</packaging>
     <description>scala-group-emailer</description>
-    <version>0.6.0-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <name>scala-group-emailer</name>
     <organization>
         <name>fi.vm.sade</name>

--- a/src/main/scala/fi/vm/sade/groupemailer/GroupEmailComponent.scala
+++ b/src/main/scala/fi/vm/sade/groupemailer/GroupEmailComponent.scala
@@ -31,6 +31,7 @@ trait GroupEmailComponent {
     )
     private val callerIdHeader = Header("Caller-Id", callerId)
     private val emailServiceUrl = uriFromString(groupEmailerSettings.groupEmailServiceUrl)
+    private val requestTimeout = Duration(30, TimeUnit.SECONDS)
 
     def uriFromString(url: String): Uri = {
       Uri.fromString(url).toOption.get
@@ -69,7 +70,7 @@ trait GroupEmailComponent {
           jobId
         case (code, resultString, uri) =>
           throw new IllegalStateException(s"Group email sending failed to ${groupEmailerSettings.groupEmailServiceUrl}. Response status was: $code. Server replied: $resultString")
-      }.runFor(Duration(10, TimeUnit.SECONDS))
+      }.runFor(requestTimeout)
     }
   }
 


### PR DESCRIPTION
Increase request timeout from 10 s to 30 s. Also: version from 0.6.0 to 0.7.0

Some requests to ryhmasahkoposti-service resulted in successfully sent emails but were recorded as failures due to taking 11-15 seconds.

"responseTime": "10364",
"responseTime": "10323",
"responseTime": "14659"